### PR TITLE
Fix missing file paths in AIO Dockerfile

### DIFF
--- a/deployments/aio/community/Dockerfile
+++ b/deployments/aio/community/Dockerfile
@@ -107,10 +107,10 @@ RUN apk add --no-cache caddy
 
 # AIO control files from your repo (these exist in the community AIO folder)
 # They define supervisor programs to run api + next apps + caddy
-COPY deployments/aio/community/dist/Caddyfile         /app/proxy/Caddyfile
+COPY apps/proxy/Caddyfile.ce         /app/proxy/Caddyfile
 COPY deployments/aio/community/start.sh               /app/start.sh
 COPY deployments/aio/community/supervisor.conf        /etc/supervisor/conf.d/supervisor.conf
-COPY deployments/aio/community/dist/plane.env         /app/plane.env
+COPY deployments/aio/community/variables.env         /app/plane.env
 
 RUN mkdir -p /app/logs/access /app/logs/error /app/data \
  && chmod +x /app/start.sh


### PR DESCRIPTION
- Fix Caddyfile path: deployments/aio/community/dist/Caddyfile → apps/proxy/Caddyfile.ce
- Fix env file path: deployments/aio/community/dist/plane.env → deployments/aio/community/variables.env
- Remove dependency on non-existent dist/ directory