### PR TITLE
Fix monorepo build by using Turbo instead of individual pnpm filters

### DIFF
--- a/deployments/aio/community/Dockerfile
+++ b/deployments/aio/community/Dockerfile
@@ -42,11 +42,8 @@ RUN pnpm install --frozen-lockfile
 COPY packages ./packages
 COPY apps ./apps
 
-# Build each Next app by path (filters by directory; works without knowing package names)
-RUN pnpm --filter ./apps/web   build && \
-    pnpm --filter ./apps/admin build && \
-    pnpm --filter ./apps/live  build && \
-    pnpm --filter ./apps/space build
+# Build all packages and apps using Turbo (handles dependencies automatically)
+RUN pnpm build
 
 # After this, each app will have its .next build output within apps/<name>.
 


### PR DESCRIPTION
- Replace individual pnpm --filter commands with pnpm build
- Use Turbo build system which handles dependency order automatically
- Fixes module resolution issues for @plane/* packages
- Ensures packages are built before apps that depend on them
