### PR TITLE
Fix container name conflict by properly removing existing AIO container

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -62,6 +62,11 @@ jobs:
             echo "Stopping existing Plane containers..."
             docker-compose down || true
             
+            # Stop and remove existing AIO container if it exists
+            echo "Stopping and removing existing AIO container..."
+            docker stop furlong-aio || true
+            docker rm furlong-aio || true
+            
             # Force stop any remaining containers using ports 80/443
             echo "Force stopping containers using ports 80/443..."
             docker stop $(docker ps -q --filter "publish=80") 2>/dev/null || true


### PR DESCRIPTION
- Add explicit stop and remove commands for existing furlong-aio container
- Prevents 'container name already in use' error during deployment
- Ensures clean container replacement for each deployment